### PR TITLE
fixed picker syntax error and UI flaw

### DIFF
--- a/SwipeSmart/Views/Cards/CardView.swift
+++ b/SwipeSmart/Views/Cards/CardView.swift
@@ -50,7 +50,5 @@ struct CardView_Previews: PreviewProvider {
     static var card = CreditCard.sampleCards[0]
     static var previews: some View {
         CardView(card: card)
-            .background(.gray)
-            .previewLayout(.fixed(width: 250, height: 150))
     }
 }

--- a/SwipeSmart/Views/Cards/DetailEditView.swift
+++ b/SwipeSmart/Views/Cards/DetailEditView.swift
@@ -47,7 +47,7 @@ struct DetailEditView: View {
                 
                 HStack {
                     Menu {
-                        Picker("Categories", selection: $selectedCategoryName) {
+                        Picker(selection: $selectedCategoryName, label: Text("")) {
                             ForEach(categories) { category in
                                 Text(category.name).tag(category.name)
                             }

--- a/SwipeSmart/Views/Category/CategoryView.swift
+++ b/SwipeSmart/Views/Category/CategoryView.swift
@@ -54,7 +54,5 @@ struct CategoryView: View {
 struct CategoryView_Previews: PreviewProvider {
     static var previews: some View {
         CategoryView(cards: .constant(CreditCard.testCards), category: .constant(Category.sampleCategories[0]))
-            .background(.gray)
-            .previewLayout(.fixed(width: 250, height: 150))
     }
 }

--- a/SwipeSmart/Views/MainView.swift
+++ b/SwipeSmart/Views/MainView.swift
@@ -18,14 +18,12 @@ struct MainView: View {
     var body: some View {
         TabView {
             CategorySelectorView(cards: $cards, categories: $categories)
-                .padding()
                 .tabItem {
                     Label("Shopping", systemImage: "cart.fill")
                 }
                 .tag(1)
 
             WalletView(cards: $cards, categories: $categories, saveAction: saveAction)
-                .padding()
                 .tabItem {
                     Label("Wallet", systemImage: "wallet.pass.fill")
                 }


### PR DESCRIPTION
fixed this picker error: Incorrect argument labels in call (have 'label:selection:_:', expected 'selection:content:label:')

Removed accidental padding around WalletVIew and CategorySelectorView