### PR TITLE
no duplicate credit cards

### DIFF
--- a/SwipeSmart/Views/Cards/CardView.swift
+++ b/SwipeSmart/Views/Cards/CardView.swift
@@ -31,11 +31,11 @@ struct CardView: View {
             RoundedRectangle(cornerRadius: 7)
                 .frame(width: 30, height: 20)
                 .padding(.bottom, 5)
-                .foregroundColor(.pastelgraylight)
+                .foregroundStyle(.pastelgraylight)
             Text("**** **** **** \(card.digits)")
         }
         .padding()
-        .foregroundColor(.primary)
+        .foregroundStyle(.primary)
     }
 }
 

--- a/SwipeSmart/Views/Cards/DetailView.swift
+++ b/SwipeSmart/Views/Cards/DetailView.swift
@@ -15,6 +15,7 @@ struct DetailView: View {
     @State private var editingCard = CreditCard.emptyCard
     @State private var editingCategories = [Category]()
     @State private var isPresentingEditView = false
+    @State private var duplicateError = false
     @Environment(\.presentationMode) var presentationMode
     
     var body: some View {
@@ -99,7 +100,7 @@ struct DetailView: View {
         }
         .sheet(isPresented: $isPresentingEditView) {
             NavigationStack {
-                DetailEditView(card: $editingCard, cards: $cards, categories: $editingCategories, showDelete: true, onDeleteCard: { deleteCard() })
+                DetailEditView(card: $editingCard, cards: $cards, categories: $editingCategories, duplicateError: $duplicateError, showDelete: true, onDeleteCard: { deleteCard() })
                     .toolbar {
                         ToolbarItem(placement: ToolbarItemPlacement.navigationBarLeading) {
                             Button("Cancel") {
@@ -108,13 +109,12 @@ struct DetailView: View {
                         }
                         ToolbarItem(placement: .confirmationAction) {
                             Button("Done") {
-                                if card.bankName.isEmpty || card.cardType.isEmpty {
-                                    return
-                                }
                                 isPresentingEditView = false
-                                card = editingCard
+                                duplicateError = false
                                 categories = editingCategories
+                                card = editingCard
                             }
+                            .disabled(editingCard.bankName.isEmpty || editingCard.cardType.isEmpty || editingCard.digits.isEmpty || duplicateError)
                         }
                     }
             }

--- a/SwipeSmart/Views/Cards/NewCreditCard.swift
+++ b/SwipeSmart/Views/Cards/NewCreditCard.swift
@@ -9,13 +9,15 @@ import SwiftUI
 struct NewCreditCard: View {
     @State private var newCard = CreditCard.emptyCard
     @State private var editingCategories = [Category]()
+    @State private var duplicateError = false
+    
     @Binding var cards: [CreditCard]
     @Binding var categories: [Category]
     @Binding var isPresentingNewCardView: Bool
     
     var body: some View {
         NavigationStack {
-            DetailEditView(card: $newCard, cards: $cards, categories: $editingCategories, showDelete: false, onDeleteCard: {})
+            DetailEditView(card: $newCard, cards: $cards, categories: $editingCategories, duplicateError: $duplicateError, showDelete: false, onDeleteCard: {})
                 .navigationTitle("Add New Card")
                 .onAppear {
                     editingCategories = categories
@@ -28,13 +30,12 @@ struct NewCreditCard: View {
                     }
                     ToolbarItem(placement: .confirmationAction) {
                         Button("Add") {
-                            if newCard.bankName.isEmpty || newCard.cardType.isEmpty {
-                                return
-                            }
-                            cards.append(newCard)
-                            categories = editingCategories
                             isPresentingNewCardView = false
+                            duplicateError = false
+                            categories = editingCategories
+                            cards.append(newCard)
                         }
+                        .disabled(newCard.bankName.isEmpty || newCard.cardType.isEmpty || newCard.digits.isEmpty || duplicateError)
                     }
                 }
         }

--- a/SwipeSmart/Views/Cards/NewRewardView.swift
+++ b/SwipeSmart/Views/Cards/NewRewardView.swift
@@ -32,10 +32,10 @@ struct NewRewardView: View {
                         } label: {
                             HStack {
                                 Text(selectedCategoryName.isEmpty ? "Select Category" : selectedCategoryName)
-                                    .foregroundColor(selectedCategoryName.isEmpty ? .gray : .primary)
+                                    .foregroundStyle(selectedCategoryName.isEmpty ? .gray : .primary)
                                 Spacer()
                                 Image(systemName: "chevron.down")
-                                    .foregroundColor(.gray)
+                                    .foregroundStyle(.gray)
                             }
                         }
                         

--- a/SwipeSmart/Views/Cards/RewardRowView.swift
+++ b/SwipeSmart/Views/Cards/RewardRowView.swift
@@ -35,10 +35,10 @@ struct RewardRowView: View {
                 } label: {
                     HStack {
                         Text(newCategoryName.isEmpty ? "Select Category" : newCategoryName)
-                            .foregroundColor(newCategoryName.isEmpty ? .gray : .primary)
+                            .foregroundStyle(newCategoryName.isEmpty ? .gray : .primary)
                         Spacer()
                         Image(systemName: "chevron.down")
-                            .foregroundColor(.gray)
+                            .foregroundStyle(.gray)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/SwipeSmart/Views/Cards/WalletView.swift
+++ b/SwipeSmart/Views/Cards/WalletView.swift
@@ -19,12 +19,12 @@ struct WalletView: View {
                 NavigationLink(destination: DetailView(card: $card, cards: $cards, categories: $categories)) {
                     CardView(card: card)
                 }
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .listRowInsets(.init(top: 30, leading: 10, bottom: 30, trailing: 15))
                 .listRowBackground(
                     RoundedRectangle(cornerRadius: 15)
                         .background(.clear)
-                        .foregroundColor(card.theme.mainColor)
+                        .foregroundStyle(card.theme.mainColor)
                         .padding(
                             EdgeInsets(
                                 top: 5,

--- a/SwipeSmart/Views/Category/CategorySelectorView.swift
+++ b/SwipeSmart/Views/Category/CategorySelectorView.swift
@@ -22,7 +22,7 @@ struct CategorySelectorView: View {
                             .listRowBackground(
                                 RoundedRectangle(cornerRadius: 15)
                                     .background(.clear)
-                                    .foregroundColor(
+                                    .foregroundStyle(
                                         cards.firstIndex(where: { $0.id == category.cardRewards.first?.cardID }).map { index in
                                             category.cardRewards.first?.expired ?? false ? .pastelgraydark : cards[index].theme.mainColor
                                         } ?? .pastelgray
@@ -38,7 +38,7 @@ struct CategorySelectorView: View {
                         .listRowBackground(
                             RoundedRectangle(cornerRadius: 15)
                                 .background(.clear)
-                                .foregroundColor(
+                                .foregroundStyle(
                                     cards.firstIndex(where: { $0.id == category.cardRewards.first?.cardID }).map { index in
                                         category.cardRewards.first?.expired ?? false ? .pastelgraydark : cards[index].theme.mainColor
                                     } ?? .pastelgraydark

--- a/SwipeSmart/Views/Category/CategoryView.swift
+++ b/SwipeSmart/Views/Category/CategoryView.swift
@@ -62,7 +62,7 @@ struct CategoryView: View {
                     .frame(width: 45, height: 45)
                     .overlay(
                         Text("\(category.cardRewards[0].reward)%")
-                            .foregroundColor(category.cardRewards[0].expired ? .pastelgraydark : cards[index].theme.mainColor)
+                            .foregroundStyle(category.cardRewards[0].expired ? .pastelgraydark : cards[index].theme.mainColor)
                             .font(.headline)
                     )
                     .padding()

--- a/SwipeSmart/Views/Category/RewardsCardView.swift
+++ b/SwipeSmart/Views/Category/RewardsCardView.swift
@@ -49,7 +49,7 @@ struct RewardsCardView: View {
                     .frame(width: 45, height: 45)
                     .overlay(
                         Text("\(reward)%")
-                            .foregroundColor(expired ? .pastelgraydark : card.theme.mainColor)
+                            .foregroundStyle(expired ? .pastelgraydark : card.theme.mainColor)
                             .font(.headline)
                     )
             }

--- a/SwipeSmart/Views/Category/RewardsView.swift
+++ b/SwipeSmart/Views/Category/RewardsView.swift
@@ -20,7 +20,7 @@ struct RewardsView: View {
                             .listRowBackground(
                                 RoundedRectangle(cornerRadius: 15)
                                     .background(.clear)
-                                    .foregroundColor(cardID_reward.expired ? .pastelgraydark : cards[index].theme.mainColor)
+                                    .foregroundStyle(cardID_reward.expired ? .pastelgraydark : cards[index].theme.mainColor)
                                     .padding(
                                         EdgeInsets(
                                             top: 5,


### PR DESCRIPTION
Credit cards cannot be duplicated (can't have same bank name, card type, and last 4 digits).

Add/Done buttons are now disabled when required fields are empty or duplicate card.

foregroundColor changed to foregroundStyle due to depreciation.