### PR TITLE
hide duplicate categories in picker

### DIFF
--- a/SwipeSmart/Models/Category.swift
+++ b/SwipeSmart/Models/Category.swift
@@ -38,6 +38,5 @@ extension Category {
         Category(name: "Travel", cardRewards: []),
         Category(name: "Dining", cardRewards: CreditCard.sampleCardRewardsDining),
         Category(name: "Gas", cardRewards: CreditCard.sampleCardRewardsGas)
-        
     ]
 }

--- a/SwipeSmart/Views/Cards/DetailEditView.swift
+++ b/SwipeSmart/Views/Cards/DetailEditView.swift
@@ -94,7 +94,7 @@ struct DetailEditView: View {
             if !card.categories.isEmpty {
                 Section(header: Text("Rewards")) {
                     ForEach(card.categories.indices, id: \.self) { index in
-                        RewardRowView(category: $card.categories[index], categories: $categories)
+                        RewardRowView(card: $card, category: $card.categories[index], categories: $categories)
                     }
                     .onDelete(perform: removeReward)
                 }

--- a/SwipeSmart/Views/Cards/NewRewardView.swift
+++ b/SwipeSmart/Views/Cards/NewRewardView.swift
@@ -25,10 +25,12 @@ struct NewRewardView: View {
                     HStack {
                         Menu {
                             Picker(selection: $selectedCategoryName, label: Text("")) {
-                                ForEach(categories) { category in
+                                ForEach(categories.filter { category in
+                                    !card.categories.contains { $0.categoryName == category.name } }) { category in
                                     Text(category.name).tag(category.name)
                                 }
                             }
+                            .labelsHidden()
                         } label: {
                             HStack {
                                 Text(selectedCategoryName.isEmpty ? "Select Category" : selectedCategoryName)
@@ -41,7 +43,6 @@ struct NewRewardView: View {
                         
                         TextField("Add Reward", text: $newUserReward)
                             .keyboardType(.numberPad)
-                            .padding(.leading)
                             .padding(.leading)
                             .textFieldStyle(.roundedBorder)
                         Text("%")

--- a/SwipeSmart/Views/Cards/RewardRowView.swift
+++ b/SwipeSmart/Views/Cards/RewardRowView.swift
@@ -7,14 +7,17 @@
 import SwiftUI
 
 struct RewardRowView: View {
+    @Binding var card: CreditCard
     @Binding var category: CreditCard.cardID_rewards
     @Binding var categories: [Category]
+    
     @State private var newCategoryName: String
     @State private var startDate: Date?
     @State private var expirationDate: Date?
     @State private var dateSet: Bool
     
-    init(category: Binding<CreditCard.cardID_rewards>, categories: Binding<[Category]>) {
+    init(card: Binding<CreditCard>,category: Binding<CreditCard.cardID_rewards>, categories: Binding<[Category]>) {
+        self._card = card
         self._category = category
         self._categories = categories
         self._newCategoryName = State(initialValue: category.wrappedValue.categoryName)
@@ -28,10 +31,13 @@ struct RewardRowView: View {
             HStack {
                 Menu {
                     Picker(selection: $newCategoryName, label: Text("")) {
-                        ForEach(categories) { category in
+                        ForEach(categories.filter { category in
+                            category.name == newCategoryName ||
+                            !card.categories.contains { $0.categoryName == category.name } }) { category in
                             Text(category.name).tag(category.name)
                         }
                     }
+                    .labelsHidden()
                 } label: {
                     HStack {
                         Text(newCategoryName.isEmpty ? "Select Category" : newCategoryName)
@@ -120,6 +126,6 @@ struct RewardRowView: View {
 
 struct RewardRowView_Previews: PreviewProvider {
     static var previews: some View {
-        RewardRowView(category: .constant(CreditCard.testCards[0].categories[0]), categories: .constant(Category.sampleCategories))
+        RewardRowView(card: .constant(CreditCard.testCards[0]),category: .constant(CreditCard.testCards[0].categories[0]), categories: .constant(Category.sampleCategories))
     }
 }


### PR DESCRIPTION
In DetailEditView, categories with existing rewards are now hidden in the category picker.

In RewardRowView, the currently selected category is not hidden.